### PR TITLE
Cancel GNOME Workshop

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -98,7 +98,7 @@
   front: true
   url: https://www.gnome.org/
   description:
-    -  An introduction to GNOME community, the projects we are developing now and the areas that people with no technical background can contribute to. After the introduction we will have the newcomers workshop, which is for developers who want to participate in coding GNOME’s apps.This workshop requires a bit of object oriented programming and git skills.
+    -  (CANCELLED) An introduction to GNOME community, the projects we are developing now and the areas that people with no technical background can contribute to. After the introduction we will have the newcomers workshop, which is for developers who want to participate in coding GNOME’s apps.This workshop requires a bit of object oriented programming and git skills.
   address:
     - "T.B.D."
   lon: 11.966646


### PR DESCRIPTION
Due to closed borders in Denmark and virus, the GNOME workshop will unfortunately not take place.